### PR TITLE
Add `supportedLevel()` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ import {
 	isSameProfile,
 	isSameProfileAndLevel,
 	generateProfileLevelIdStringForAnswer,
+	supportedLevel,
 } from 'h264-profile-level-id';
 ```
 
@@ -154,6 +155,17 @@ generateProfileLevelIdStringForAnswer(
 Generate a profile level id that is represented as a string of 3 hex bytes suitable for an answer in an SDP negotiation based on local supported parameters and remote offered parameters. The parameters that are used when negotiating are the level part of `profile-level-id` and `level-asymmetry-allowed`.
 
 **NOTE:** This function is just intended to manage H264 profile levels ids with same profile (otherwise it will throw). Use `isSameProfile()` API before this one.
+
+### Function `supportedLevel()`
+
+```ts
+supportedLevel(
+	max_frame_pixel_count: number,
+	max_fps: number
+): Level | undefined
+```
+
+Given that a decoder supports up to a given frame size (in pixels) at up to a given number of frames per second, return the highest H264 level where it can guarantee that it will be able to support all valid encoded streams that are within that level.
 
 ## Usage examples
 

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -8,6 +8,7 @@ import {
 	isSameProfile,
 	isSameProfileAndLevel,
 	generateProfileLevelIdStringForAnswer,
+	supportedLevel,
 } from '../';
 
 describe('parseProfileLevelId()', () => {
@@ -333,5 +334,25 @@ describe('generateProfileLevelIdStringForAnswer()', () => {
 		expect(
 			generateProfileLevelIdStringForAnswer(local_params, remote_params)
 		).toBe('42e01f');
+	});
+});
+
+describe('supportedLevel()', () => {
+	test('valid values', () => {
+		expect(supportedLevel(640 * 480, 25)).toBe(Level.L2_1);
+
+		expect(supportedLevel(1280 * 720, 30)).toBe(Level.L3_1);
+
+		expect(supportedLevel(1920 * 1280, 60)).toBe(Level.L4_2);
+	});
+
+	test('invalid values', () => {
+		expect(supportedLevel(0, 0)).toBeUndefined();
+
+		// All levels support fps > 5.
+		expect(supportedLevel(1280 * 720, 5)).toBeUndefined();
+
+		// All levels support frame sizes > 183 * 137.
+		expect(supportedLevel(183 * 137, 30)).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Details

- Fixes #4
- Add `supportedLevel()` public function.

```ts
supportedLevel(
	max_frame_pixel_count: number,
	max_fps: number
): Level | undefined
```

Given that a decoder supports up to a given frame size (in pixels) at up to a given number of frames per second, return the highest H264 level where it can guarantee that it will be able to support all valid encoded streams that are within that level.